### PR TITLE
Implementação da validação do campo Ano segundo o Java Calendar e do …

### DIFF
--- a/src/main/java/org/jabref/logic/integrity/BibtexKeyChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/BibtexKeyChecker.java
@@ -30,6 +30,13 @@ public class BibtexKeyChecker implements Checker {
                     Localization.lang("empty BibTeX key") + ": " + authorTitleYear, entry, BibEntry.KEY_FIELD));
         }
 
+        //Checks if the Bibtexkey informed is valid
+        String bibkeypattern = author.toString() + year.toString() + title.toString().toUpperCase();
+        if(!entry.toString().equals(bibkeypattern)) {
+            return Collections.singletonList(new IntegrityMessage(
+                    Localization.lang("invalid BibTeX key: expected AuthorYYYYTITLE"), entry, BibEntry.KEY_FIELD));
+        }
+
         return Collections.emptyList();
     }
 }

--- a/src/main/java/org/jabref/logic/integrity/YearChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/YearChecker.java
@@ -7,6 +7,8 @@ import java.util.regex.Pattern;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.strings.StringUtil;
 
+import java.util.Calendar;
+
 public class YearChecker implements ValueChecker {
 
     private static final Predicate<String> CONTAINS_FOUR_DIGIT = Pattern.compile("([^0-9]|^)[0-9]{4}([^0-9]|$)")
@@ -23,6 +25,7 @@ public class YearChecker implements ValueChecker {
      */
     @Override
     public Optional<String> checkValue(String value) {
+
         if (StringUtil.isBlank(value)) {
             return Optional.empty();
         }
@@ -33,6 +36,19 @@ public class YearChecker implements ValueChecker {
 
         if (!ENDS_WITH_FOUR_DIGIT.test(value.replaceAll(PUNCTUATION_MARKS, ""))) {
             return Optional.of(Localization.lang("last four nonpunctuation characters should be numerals"));
+        }
+
+        //check if is a year valid by Java Calendar
+        Calendar cal = Calendar.getInstance();
+        cal.setLenient(false);
+        try {
+            cal.set(Calendar.YEAR, Integer.parseInt(value));
+            if (cal.get(Calendar.YEAR) != Integer.parseInt(value)){
+                return Optional.of(Localization.lang("is not a valid year"));
+            }
+
+        } catch (Exception e) {
+            return Optional.of(Localization.lang("is not a valid year"));
         }
 
         return Optional.empty();


### PR DESCRIPTION
…campo BibTeXkey segundo o padrão Sobrenome do Primeiro Autor + Ano com 4 digitos + Primeira Palavra do Título do Artigo toda em Maiúscula.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
