### PR TITLE
Fix #4169: generate bibtexkey for chinese authors

### DIFF
--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
@@ -171,6 +171,10 @@ public class BracketedPattern {
                     authString = entry.getResolvedFieldOrAlias(FieldName.AUTHOR, database).orElse("");
                 }
 
+                if (authString.codePoints().anyMatch(codepoint ->Character.UnicodeScript.of(codepoint) == Character.UnicodeScript.HAN)){
+                    authString = authString.replaceAll(",", "");
+                }
+
                 if (val.startsWith("pure")) {
                     // "pure" is used in the context of authors to resolve to authors only and not fallback to editors
                     // The other functionality of the pattern "ForeIni", ... is the same


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
